### PR TITLE
Clean up CSS vars

### DIFF
--- a/styles/styleSheet.css
+++ b/styles/styleSheet.css
@@ -5,30 +5,13 @@
 	--alternate-background-color: #f0f0f0;
 	--main-border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 	--nav-background-color: rgba(0, 0, 0, 0.75);
-	--nav-top-border: 1px solid rgba(0, 0, 0, 0.1);
-	--nav-bottom-border: 1px solid rgba(0, 0, 0, 0.1);
 	--nav-link-color: rgba(255, 255, 255, 0.9);
 	--color: rgba(0, 0, 0, 0.75);
 	--link-color: hsl(214, 65%, 55%);
 	--link-visited-color: hsl(250, 27%, 56%);
-	--bold-color: rgba(0, 0, 0, 0.75);
-	--biglink-color: hsl(5, 56%, 55%);
-	--widequote-background-color: rgba(0, 0, 0, 0.85);
-	--widequote-color: rgba(255, 255, 255, 0.9);
-	--widequote-border: 1px solid black;
 	--separator-background-color: rgba(0, 0, 0, 0.1);
-	--box-shadow: 0px 1px 0px white;
-	--text-shadow: 0px 1px white;
-	--downloads-background-color: var(--biglink-color);
-	--downloads-border-top: 1px solid hsl(5, 56%, 40%);
-	--downloads-separator-background-color: rgba(255, 255, 255, 0.2);
-	--downloads-link-color: rgba(255, 255, 255, 0.9);
-	--pressdate-color: rgba(0, 0, 0, 0.35);
 	--note-color: rgba(0, 0, 0, 0.35);
-	--intro-bottom-border: 1px solid white;
-	--lightlink-color: var(--link-color);
 	--footer-color: rgba(0, 0, 0, 0.5);
-	--system-requirements-color: rgba(255, 255, 255, 0.75);
 	--screenshot-shadow: 0 10px 15px 10px rgba(164, 164, 164, 0.1);
 }
 @media(prefers-color-scheme: dark) {
@@ -37,29 +20,15 @@
 	--alternate-background-color: rgba(255, 255, 255, 0.1);
 	--main-border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 	--nav-background-color: rgba(0, 0, 0, 0.75);
-	--nav-top-border: 1px solid rgba(0, 0, 0, 0.15);
-	--nav-bottom-border: 1px solid rgba(0, 0, 0, 0.15);
 	--nav-link-color: rgba(255, 255, 255, 0.5);
 	--color: rgba(255, 255, 255, 0.8);
 	--link-color: hsl(214, 65%, 55%);
 	--link-visited-color: hsl(250, 27%, 56%);
-	--bold-color: rgba(255, 255, 255, 0.95);
-	--biglink-color: rgba(255, 255, 255, 0.95);
-	--widequote-background-color: black;
-	--widequote-color: rgba(255, 255, 255, 0.8);
-	--widequote-border: 1px solid black;
 	--separator-background-color: rgba(255, 255, 255, 0.35);
-	--box-shadow: none;
-	--text-shadow: none;
-	--downloads-background-color: rgba(255, 255, 255, 0.1);
-	--downloads-border-top: 1px solid rgba(0, 0, 0, 0.5);
-	--downloads-separator-background-color: rgba(255, 255, 255, 0.1);
-	--pressdate-color: rgba(255, 255, 255, 0.5);
-	--intro-bottom-border: none;
-	--lightlink-color: rgba(255, 255, 255, 0.9);
+	--note-color: rgba(255, 255, 255, 0.35);
 	--footer-color: rgba(255, 255, 255, 0.5);
-	--system-requirements-color: rgba(255, 255, 255, 0.75);
 	--screenshot-shadow: none;
+
 	}
 }
 
@@ -376,12 +345,12 @@ p.note, span.note {
 @media (min-width: 760px)
 {
 	div.columns { display: flex; }
-	
+
 	div.column-left
 	{
 		padding: 0 0.5em 0 0;
 	}
-	
+
 	div.column-right
 	{
 		padding: 0 0 0 0.5em;


### PR DESCRIPTION
## Problem

A certain piece of text in dark mode uses light mode coloring.

<img width="699" alt="image" src="https://user-images.githubusercontent.com/190134/162837116-ca7cad3d-0e62-46a2-ab3b-ecd05b0dd84b.png">

## Solution

Adds the missing dark mode variant color variable.

<img width="678" alt="image" src="https://user-images.githubusercontent.com/190134/162837168-1bbff6be-975d-43a3-a244-93bb852de710.png">

Also, I verified each other variable and removed all the unused ones.

## Notes

Fixes https://github.com/Ranchero-Software/NetNewsWire/issues/3526
