### PR TITLE
Fix link to notifications.html

### DIFF
--- a/pages/ios/6.1/en/index.markdown
+++ b/pages/ios/6.1/en/index.markdown
@@ -37,7 +37,7 @@ Filter to hide read items](filters.html)
 
 [Sort the timeline by oldest or newest](sorting-the-timeline.html)
 
-[See notifications and badges for new articles](notification.htmls)
+[See notifications and badges for new articles](notifications.html)
 
 [Share to other apps](sharing-articles.html)
 


### PR DESCRIPTION
Hello! I noticed the link to the notifications page 404s. The notifications are a really cool feature so I'm happy to get this link fixed!